### PR TITLE
Avoid null-pointer arithmetic, amended.

### DIFF
--- a/picosat.c
+++ b/picosat.c
@@ -2382,11 +2382,11 @@ REENTER:
 	  for (p = ps->added; p < ps->ahead; p++) 
 	    {
 	      lit = *p;
-	      if (lit->val && ps->levels)
+	      if (lit->val)
 		{
 		  litlevel = LIT2VAR (lit)->level;
 		  assert (litlevel <= ps->LEVEL);
-		  while (ps->levels + litlevel >= ps->levelshead)
+		  while (!ps->levels || (ps->levels + litlevel >= ps->levelshead))
 		    {
 		      if (ps->levelshead >= ps->eolevels)
 			ENLARGE (ps->levels, ps->levelshead, ps->eolevels);
@@ -2403,7 +2403,7 @@ REENTER:
 		      glue++;
 		    }
 		}
-	      else if (!lit->val)
+	      else
 		glue++;
 	    }
 
@@ -3430,9 +3430,9 @@ satisfied (PS * ps)
     return 0;
   assert (!ps->conflict);
   assert (bcp_queue_is_empty (ps));
-  if (ps->trail == NULL)
-    return ps->thead == NULL;
-  return ps->thead == ps->trail + ps->max_var;	/* all assigned */
+  return ps->trail
+      ? (ps->thead == ps->trail + ps->max_var) /* all assigned */
+      : (ps->max_var == 0); /* ps->trail was NULL, so avoid ptr arithmetic */
 }
 
 static void


### PR DESCRIPTION
The first attempt (PR#1) inadvertently made some implementation behavior
unreachable.

The second attempt (PR#2) failed debug-time assertion checks.